### PR TITLE
Fixed an issue where for some reasons events.constructor isn't the same as Array on firefox, but is on chromium

### DIFF
--- a/src/magister/scripts/today.js
+++ b/src/magister/scripts/today.js
@@ -385,7 +385,7 @@ async function today() {
         const events = await MagisterApi.events()
 
         // Display error if the result does not exist or if it is not an array
-        if (!(events?.constructor === Array)) {
+        if (!events || !Array.isArray(events)) {
             element('i', `st-start-fa`, schedule, { class: 'st-start-icon fa-duotone fa-calendar-circle-exclamation' })
             element('span', `st-start-disclaimer`, schedule, { class: 'st-start-disclaimer', innerText: i18n('error') })
             return


### PR DESCRIPTION
Fetching the events for the start page via ```MagisterApi.events()```, returns an array or null.
However, when checking if it is an array via ```events?.constructor === Array``` it somehow results in false on Firefox, but results in true on chromium. Meaning that the today page always shows an error on Firefox, even if it shouldn't.

I replaced the content inside the if statement with ```!events || !Array.isArray(events)```, which does work on both chromium and firefox.